### PR TITLE
Add disabled attribute.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,16 @@
   </head>
   <body>
     <example-app>
-      <input type="text" name="input" @disabled="greeting">
+      <input type="text" name="input" @disabled="greeting" value="this works">
+      <textarea name="text" @disabled="greeting">
+        This works
+      </textarea>
+      <p @disabled="greeting">This should thow error</p>
+      <select name="select" @disabled="greeting">
+        <option value="value1">Value 1</option> 
+        <option value="value2" selected>This works too</option>
+        <option value="value3">Value 3</option>
+      </select>
       <input type="checkbox" name="greeting" bind>
       @{greeting}
     </example-app>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script src="./nx.js" type="text/javascript"></script>
+    <script>
+      nx.components.app().register('example-app')
+    </script>
+  </head>
+  <body>
+    <example-app>
+      <input type="text" name="input" @disabled="greeting">
+      <input type="checkbox" name="greeting" bind>
+      @{greeting}
+    </example-app>
+  </body>
+</html>

--- a/middlewares/attributes.js
+++ b/middlewares/attributes.js
@@ -16,9 +16,19 @@ module.exports = function attributes (elem, state, next) {
   processAttributesWithHandler(elem, state)
 }
 
+function isInput (elem) {
+  if (elem instanceof HTMLInputElement) return true
+  if (elem instanceof HTMLTextAreaElement) return true
+  if (elem instanceof HTMLSelectElement) return true
+  return false
+}
+
 function $attribute (name, handler) {
   if (typeof name !== 'string') {
     throw new TypeError('first argument must be a string')
+  }
+  if (name === 'disabled' && !isInput(this)) {
+    throw new TypeError('cannot disable given element')
   }
   if (typeof handler !== 'function') {
     throw new TypeError('second argument must be a function')

--- a/middlewares/attributes.js
+++ b/middlewares/attributes.js
@@ -28,7 +28,7 @@ function $attribute (name, handler) {
     throw new TypeError('first argument must be a string')
   }
   if (name === 'disabled' && !isInput(this)) {
-    throw new TypeError('cannot disable given element')
+    throw new TypeError(`Element ${this} cannot be disabled`)
   }
   if (typeof handler !== 'function') {
     throw new TypeError('second argument must be a function')

--- a/middlewares/flow.js
+++ b/middlewares/flow.js
@@ -2,6 +2,7 @@
 
 const secret = {
   hasIf: Symbol('flow hasIf'),
+  disabled: Symbol('flow disabled'),
   showing: Symbol('flow showing'),
   hasRepeat: Symbol('flow hasRepeat'),
   prevArray: Symbol('flow prevArray')
@@ -14,8 +15,19 @@ module.exports = function flow (elem, state, next) {
 
   elem.$attribute('if', ifAttribute)
   elem.$attribute('repeat', repeatAttribute)
+  elem.$attribute('disabled', disableAttribute)
 
   return next()
+}
+
+function disableAttribute (disabled, elem) {
+  if (disabled && !elem[secret.disabled]) {
+    elem[secret.disabled] = true
+    elem.setAttribute('disabled', 'disabled')
+  } else if (!disabled && elem[secret.disabled]) {
+    elem[secret.disabled] = false
+    elem.removeAttribute('disabled')
+  }
 }
 
 function ifAttribute (show, elem) {


### PR DESCRIPTION
The `index.html` is just for demo purpose and will be removed after approval.

Changelog:
1. Add `disabled` attribute to disable elements on boolean conditions.
2. Add pre-checks and throw error if element cannot have the above attribute.

Issue:

At present the `disabled` attribute is applied to all the `option` attribute of the `select` element and hence throws err.
